### PR TITLE
Add ARM64 Docker image publishing workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,43 @@
+name: Build and publish ARM64 Docker image
+
+on:
+  push:
+    branches:
+      - raspberry-pi-arm64-support
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/skyeblu7/homebranch-auth
+
+jobs:
+  docker-arm64:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ARM64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:arm64
+            ${{ env.IMAGE_NAME }}:raspberry-pi
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64


### PR DESCRIPTION
This PR adds Raspberry Pi / ARM64 Docker image publishing for the authentication service.

Changes:
- Adds a GitHub Actions workflow that builds and publishes a linux/arm64 Docker image to GHCR.
- Enables Raspberry Pi users to pull an ARM64-compatible authentication service image.

Tested:
- GitHub Actions build completed successfully.
- Verified the published image pulls on Raspberry Pi / ARM64.
- Verified the image architecture is arm64.